### PR TITLE
Update gems; use new Typhoeus

### DIFF
--- a/c2dm_batch.gemspec
+++ b/c2dm_batch.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = %w(lib)
   s.test_files = `cd #{root} && git ls-files -- {features,test,spec}/*`.split("\n")
 
-  s.add_development_dependency "rspec", "~> 1.0"
-  s.add_dependency "typhoeus", "= 0.2.4"
-  s.add_dependency "json", "= 1.6.1"
+  s.add_development_dependency "rspec"
+  s.add_dependency "typhoeus"
+  s.add_dependency "json"
 end

--- a/lib/c2dm_batch.rb
+++ b/lib/c2dm_batch.rb
@@ -1,7 +1,6 @@
 require "rubygems"
 require "yaml"
 require "cgi"
-gem 'typhoeus', '= 0.2.4'
 require "typhoeus"
 require 'logger'
 require 'json'

--- a/spec/c2dm_batch/core_spec.rb
+++ b/spec/c2dm_batch/core_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe C2dmBatch do
+  after do
+    Typhoeus::Expectation.clear
+  end
+
   before do
     @config = YAML::load(File.open("config.yml"))
     @c2dm_batch = C2dmBatch.new
@@ -53,7 +57,7 @@ describe C2dmBatch do
   it "should abort on 503 and return remaining requests" do
     hydra = Typhoeus::Hydra.new
     response = Typhoeus::Response.new(:code => 503, :headers => "", :body => "registration=123")
-    hydra.stub(:post, 'https://android.apis.google.com/c2dm/send').and_return(response)
+    Typhoeus.stub('https://android.apis.google.com/c2dm/send').and_return(response)
     @c2dm_batch.instance_variable_set("@hydra", hydra)
     teams = [ "buffalo-bills", "miami-dolphins", "new-york-jets"]
     notifications = []

--- a/spec/c2dm_batch/core_spec.rb
+++ b/spec/c2dm_batch/core_spec.rb
@@ -43,8 +43,9 @@ describe C2dmBatch do
 
   it "should return MessageToBig status code" do
     notifications = []
-    notifications << create_notification(@reg_id, "1" * 1025)
+    notifications << create_notification(@reg_id, "1" * 2048)
     errors = @c2dm_batch.send_batch_notifications(notifications)
+    errors.size.should == 1
     errors[0][:registration_id].should == @reg_id
     errors[0][:error].should == "MessageTooBig"
   end


### PR DESCRIPTION
Patch updates c2dm_batch to use the newest version of Typhoeus.

Changes needed include using the newer Typhoeus Request class, fixing Typhoeus stubbing in a test. I have also updated the test for MessageTooBig with a large enough value (2048) - a smaller value may probably suffice, I didn't really try.
